### PR TITLE
Pull request regex support

### DIFF
--- a/lib/elasticsearch/adapter.go
+++ b/lib/elasticsearch/adapter.go
@@ -227,7 +227,8 @@ func (a *Adapter) Read(req []*prompb.Query) ([]*prompb.QueryResult, error) {
 func (a *Adapter) buildCommand(q *prompb.Query) *elastic.SearchService {
 
 	query := elastic.NewBoolQuery()
-	for _, m := range q.Matchers {
+//  Not sure if it is useful 
+/*	for _, m := range q.Matchers {
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
 			query = query.Filter(elastic.NewTermQuery("label."+m.Name, m.Value))
@@ -238,7 +239,7 @@ func (a *Adapter) buildCommand(q *prompb.Query) *elastic.SearchService {
 			log.Panic("unknown match", zap.String("type", m.Type.String()))
 		}
 	}
-
+*/
 	query = query.Filter(elastic.NewRangeQuery("timestamp").Gte(q.StartTimestampMs).Lte(q.EndTimestampMs))
 
 	// ss, _ := elastic.NewSearchSource().Query(query).Source()

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - ELASTICSEARCH_PASSWORD=MagicWord
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.1.0
     ports:
       - '9090:9090'
     # command:


### PR DESCRIPTION
Hi,

We can't do a query with a regex expression in Prometheus when we are using the Prometheus-es-adapter.

The problem seems to be related to the "for" statement on the line 231 in the file adapter.go.
I'm not a golang expert but I think this statement is not necessary because you've assigned the variable "query" in the "for" statement at line 233  and then at the line 243, you reassign same with something else.

Without the "for" statement, you can do query with a regex in Prometheus.

Regards,

Yanick