### PR TITLE
Query enhancements

### DIFF
--- a/lib/elasticsearch/adapter.go
+++ b/lib/elasticsearch/adapter.go
@@ -225,15 +225,17 @@ func (a *Adapter) Read(req []*prompb.Query) ([]*prompb.QueryResult, error) {
 }
 
 func (a *Adapter) buildCommand(q *prompb.Query) *elastic.SearchService {
-
 	query := elastic.NewBoolQuery()
 	for _, m := range q.Matchers {
 		switch m.Type {
 		case prompb.LabelMatcher_EQ:
 			query = query.Filter(elastic.NewTermQuery("label."+m.Name, m.Value))
-		// case prompb.LabelMatcher_NEQ:
-		// case prompb.LabelMatcher_RE:
-		// case prompb.LabelMatcher_NRE:
+		case prompb.LabelMatcher_NEQ:
+			query = query.MustNot(elastic.NewTermQuery("label."+m.Name, m.Value))
+		case prompb.LabelMatcher_RE:
+			query = query.Filter(elastic.NewRegexpQuery("label."+m.Name, m.Value))
+		case prompb.LabelMatcher_NRE:
+			query = query.MustNot(elastic.NewRegexpQuery("label."+m.Name, m.Value))
 		default:
 			log.Panic("unknown match", zap.String("type", m.Type.String()))
 		}

--- a/lib/elasticsearch/index.go
+++ b/lib/elasticsearch/index.go
@@ -20,7 +20,16 @@ const activeIndexTemplate = `{
 		"search-prom-metrics": {}
 	},
 	"mappings":{
-		"sample": {
+		"_default_": {
+      "_all": {
+        "enabled": false
+      },
+			"properties": {
+				"timestamp": {
+					"type": "date",
+					"format": "strict_date_optional_time||epoch_millis"
+				}
+			},
 			"dynamic_templates": [
 				{
 					"strings": {


### PR DESCRIPTION
- [x] Disable the `_all` field for indexing, this will improve throughput
- [x] Give datetime field mapping to the `timestamp` field, this will allow browsing all the metrics on kibana
- [x] Support all the queries - RE, NRE, NE

Tested with prometheus kubernetes cluster monitoring graph that has all these operators:

<img width="1392" alt="screen shot 2018-04-01 at 02 29 53" src="https://user-images.githubusercontent.com/1570745/38168705-4f72ae0c-3555-11e8-9c4b-0f285ceb8139.png">

<img width="1392" alt="screen shot 2018-04-01 at 02 30 52" src="https://user-images.githubusercontent.com/1570745/38168706-54ddd704-3555-11e8-891d-f0dff9d77d4d.png">

<img width="1392" alt="screen shot 2018-04-01 at 02 31 31" src="https://user-images.githubusercontent.com/1570745/38168707-58ed2a34-3555-11e8-83b7-99a62f5311ee.png">
