### PR TITLE
Add root CAs for TLS endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ LABEL REPO="https://github.com/pwillie/prometheus-es-adapter"
 LABEL GIT_COMMIT=$GIT_COMMIT
 LABEL VERSION=$VERSION
 
+RUN apk add -U ca-certificates
+
 # Because of https://github.com/docker/docker/issues/14914
 ENV PATH=$PATH:/opt/prometheus-es-adapter/bin
 


### PR DESCRIPTION
This fixes the following issue when connecting to an AWS ES endpoint via https:

`health check timeout: Head https://the-endpoint: x509: failed to load system roots and no roots provided: no Elasticsearch node available"`