### PR TITLE
Log http.ListenAndServe failures

### DIFF
--- a/lib/elasticsearch/adapter.go
+++ b/lib/elasticsearch/adapter.go
@@ -122,17 +122,17 @@ func SetEsUrl(url string) AdapterOptionFunc {
 }
 
 func SetEsUser(user string) AdapterOptionFunc {
-        return func(a *Adapter) error {
-                a.esUser = user
-                return nil
-        }
+	return func(a *Adapter) error {
+		a.esUser = user
+		return nil
+	}
 }
 
- func SetEsPassword(pass string) AdapterOptionFunc {
-        return func(a *Adapter) error {
-                a.esPassword = pass
-                return nil
-        }
+func SetEsPassword(pass string) AdapterOptionFunc {
+	return func(a *Adapter) error {
+		a.esPassword = pass
+		return nil
+	}
 }
 
 func SetEsIndexMaxAge(age string) AdapterOptionFunc {

--- a/main.go
+++ b/main.go
@@ -153,5 +153,7 @@ func main() {
 	})
 
 	log.Info(fmt.Sprintf("Listening on %+v", *listen))
-	http.ListenAndServe(*listen, nil)
+	if err := http.ListenAndServe(*listen, nil); err != nil {
+		log.Fatal("http.ListenAndServe error", zap.Error(err))
+	}
 }


### PR DESCRIPTION
Gofmt also caught `lib/elasticsearch/adapter.go` so I figured I might as well include that.

Very minor usability nit. If you pass invalid `--listen` strings, there previously was just a silent failure and exit. Now it logs the error so you know that you made a mistake.