### PR TITLE
close

### DIFF
--- a/pkg/elasticsearch/write.go
+++ b/pkg/elasticsearch/write.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"go.uber.org/zap"
-	elastic "gopkg.in/olivere/elastic.v6"
+	"gopkg.in/olivere/elastic.v6"
 )
 
 type prometheusSample struct {
@@ -96,9 +96,11 @@ func (svc *WriteService) Write(req []*prompb.TimeSeries) {
 // after is invoked by bulk processor after every commit.
 // The err variable indicates success or failure.
 func (svc *WriteService) after(id int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
-	for _, i := range response.Items {
-		if i["index"].Status != 201 {
-			svc.logger.Error(fmt.Sprintf("%+v", i["index"].Error))
+	if response != nil {
+		for _, i := range response.Items {
+			if i["index"].Status != 201 {
+				svc.logger.Error(fmt.Sprintf("%+v", i["index"].Error))
+			}
 		}
 	}
 }


### PR DESCRIPTION
在我对prometheus-es-adapter做压测的时候，会因为es繁忙导致panic，
1，one Elasticsearch server  use docker images: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
2, set ES_WORKERS=100 
3, Number of requests to run concurrently is 200 /使用200的并发压测
错误如下：
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xa13c19]

goroutine 74 [running]:
github.com/pwillie/prometheus-es-adapter/pkg/elasticsearch.(*WriteService).after(0xc0001c2140, 0x5a32, 0xc000f1c000, 0x13, 0x20, 0x0, 0xc6f360, 0xc000b5a750)
        /go/src/github.com/pwillie/prometheus-es-adapter/pkg/elasticsearch/write.go:99 +0x29
github.com/pwillie/prometheus-es-adapter/pkg/elasticsearch.(*WriteService).after-fm(0x5a32, 0xc000f1c000, 0x13, 0x20, 0x0, 0xc6f360, 0xc000b5a750)
        /go/src/github.com/pwillie/prometheus-es-adapter/pkg/elasticsearch/write.go:51 +0x73
github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic%2ev6.(*bulkWorker).commit(0xc0002a6ac0, 0xc76300, 0xc0000240a8, 0x1, 0xc0002d7c80)
        /go/src/github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic.v6/bulk_processor.go:588 +0x37d
github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic%2ev6.(*bulkWorker).work(0xc0002a6ac0, 0xc76300, 0xc0000240a8)
        /go/src/github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic.v6/bulk_processor.go:487 +0x48a
created by github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic%2ev6.(*BulkProcessor).Start
        /go/src/github.com/pwillie/prometheus-es-adapter/vendor/gopkg.in/olivere/elastic.v6/bulk_processor.go:336 +0x1bb
 修改代码打印出after函数错误遇到两种情况：
1，Post http://127.0.0.1:9200/_bulk: dial tcp 127.0.0.1:9200: connect: cannot assign requested address
2，no available connection: no Elasticsearch node available